### PR TITLE
Update syntax/dosini.vim to the latest version

### DIFF
--- a/runtime/syntax/dosini.vim
+++ b/runtime/syntax/dosini.vim
@@ -1,12 +1,12 @@
 " Vim syntax file
 " Language:               Configuration File (ini file) for MSDOS/MS Windows
-" Version:                2.2
+" Version:                2.3
 " Original Author:        Sean M. McKee <mckee@misslink.net>
 " Previous Maintainer:    Nima Talebi <nima@it.net.au>
 " Current Maintainer:     Hong Xu <hong@topbug.net>
 " Homepage:               http://www.vim.org/scripts/script.php?script_id=3747
 " Repository:             https://github.com/xuhdev/syntax-dosini.vim
-" Last Change:            2018 Sep 11
+" Last Change:            2023 Jun 27
 
 
 " quit when a syntax file was already loaded
@@ -24,6 +24,8 @@ syn match  dosiniNumber   "=\zs\s*\d*\.\d\+\s*$"
 syn match  dosiniNumber   "=\zs\s*\d\+e[+-]\=\d\+\s*$"
 syn region dosiniHeader   start="^\s*\[" end="\]"
 syn match  dosiniComment  "^[#;].*$"
+syn region dosiniSection  start="\s*\[.*\]" end="\ze\s*\[.*\]" fold
+      \ contains=dosiniLabel,dosiniValue,dosiniNumber,dosiniHeader,dosiniComment
 
 " Define the default highlighting.
 " Only when an item doesn't have highlighting yet


### PR DESCRIPTION
The latest version is hosted at https://github.com/xuhdev/syntax-dosini.vim/blob/master/syntax/dosini.vim. I sent a file to Bram in Late June but he didn't get the chance to update this runtime file. RIP!